### PR TITLE
Fix for getting listObjects from filtered list with nil predicate

### DIFF
--- a/RZCollectionList/RZFilteredCollectionList.m
+++ b/RZCollectionList/RZFilteredCollectionList.m
@@ -296,7 +296,7 @@ typedef enum {
 
 - (NSArray*)listObjects
 {
-    return [[self.sourceList listObjects] filteredArrayUsingPredicate:self.predicate];
+    return (self.predicate == nil ? [self.sourceList listObjects] : [[self.sourceList listObjects] filteredArrayUsingPredicate:self.predicate]);
 }
 
 - (NSArray*)sections


### PR DESCRIPTION
An exception was being thrown if you tried to get a filtered collection list's objects when its predicate was nil.
