### PR TITLE
Fixed index path for object updates when removing a section

### DIFF
--- a/RZCollectionList/RZArrayCollectionList.m
+++ b/RZCollectionList/RZArrayCollectionList.m
@@ -447,7 +447,7 @@
             
             if (shouldSendNotifications)
             {
-                [self sendDidChangeObjectNotification:obj atIndexPath:[NSIndexPath indexPathForRow:idx inSection:sectionInfo.indexOffset] forChangeType:RZCollectionListChangeDelete newIndexPath:nil];
+                [self sendDidChangeObjectNotification:obj atIndexPath:[NSIndexPath indexPathForRow:idx inSection:index] forChangeType:RZCollectionListChangeDelete newIndexPath:nil];
             }
         }];
     }


### PR DESCRIPTION
The index path was being constructed with a section index equal to the section's row offset, not its section index. Bugs ensued.
