### PR TITLE
Filtered section info retains its source info

### DIFF
--- a/RZCollectionList/Classes/RZFilteredCollectionList.m
+++ b/RZCollectionList/Classes/RZFilteredCollectionList.m
@@ -14,7 +14,7 @@
 
 @property (nonatomic, strong, readwrite) NSArray *objects;
 
-@property (nonatomic, weak) id<RZCollectionListSectionInfo> sourceSectionInfo;
+@property (nonatomic, strong) id<RZCollectionListSectionInfo> sourceSectionInfo;
 @property (nonatomic, weak) RZFilteredCollectionList *filteredList;
 
 @property (nonatomic, assign) BOOL isCachedCopy;


### PR DESCRIPTION
@joe-goullaud 
There is a bug I missed that seems like it could be fairly common. Fetched collection list generates its section info on-demand, so if a filtered list is observing a fetched list, the weak source section info property would go to nil basically immediately, resulting in an apparent zero-object section in the final list.

I can't think of a case where having this strong would cause a retain cycle, so I think this is safe.
