### PR TITLE
Don't unnecessarily perform block animations

### DIFF
--- a/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.h
+++ b/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.h
@@ -16,9 +16,9 @@
 
 @optional
 
-//! Implement this to immediately update a cell's contents as part of a batch update, as opposed to a parallel animation (which can look strange)
+//! Implement this to immediately update a cell's contents as part of a batch update, as opposed to reloading after a batch animatino
 /*!
-    The indexPath parameter is the index path of the object in the collection list at the time this method is called, NOT the index path of the cell being updated.
+    The indexPath parameter is the index path of the object in the collection list at the time this method is called, NOT the index path of the cell being updated!!
  */
 - (void)collectionView:(UICollectionView*)collectionView updateCell:(UICollectionViewCell*)cell forObject:(id)object atIndexPath:(NSIndexPath*)indexPath;
 

--- a/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.m
+++ b/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.m
@@ -15,9 +15,10 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
 @property (nonatomic, strong, readwrite) id<RZCollectionList> collectionList;
 @property (nonatomic, weak, readwrite) UICollectionView *collectionView;
 @property (nonatomic, strong) NSMutableArray *batchUpdates;
-@property (nonatomic, strong) NSMutableArray *updatedIndexPaths;
-
 @property (nonatomic, strong) NSMutableArray *insertedSectionIndexes;
+
+@property (nonatomic, assign) BOOL delegateImplementsInPlaceUpdate;
+@property (nonatomic, assign) BOOL reloadAfterAnimation;
 
 @end
 
@@ -47,6 +48,12 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
 - (void)dealloc
 {
     [self.collectionList removeCollectionListObserver:self];
+}
+
+- (void)setDelegate:(id<RZCollectionListCollectionViewDataSourceDelegate>)delegate
+{
+    _delegate = delegate;
+    self.delegateImplementsInPlaceUpdate = [delegate respondsToSelector:@selector(collectionView:updateCell:forObject:atIndexPath:)];
 }
 
 #pragma mark - UICollectionViewDataSource
@@ -94,13 +101,13 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
                 if (self.useBatchUpdating){
                 
                     // If the delegate implements the update method, update right now. Otherwise delay.
-                    if ([self.delegate respondsToSelector:@selector(collectionView:updateCell:forObject:atIndexPath:)])
+                    if (self.delegateImplementsInPlaceUpdate)
                     {
                         [self.delegate collectionView:self.collectionView updateCell:cell forObject:object atIndexPath:newIndexPath];
                     }
                     else
                     {
-                        [self.updatedIndexPaths addObject:newIndexPath];
+                        self.reloadAfterAnimation = YES;
                     }
                 }
                 else
@@ -196,7 +203,7 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
     {
         if (self.useBatchUpdating)
         {
-            self.updatedIndexPaths = [NSMutableArray array];
+            self.reloadAfterAnimation = NO;
             self.batchUpdates = [NSMutableArray array];
             self.insertedSectionIndexes = [NSMutableArray array];
         }
@@ -220,23 +227,14 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
                     
                 } completion:^(BOOL finished) {
                     
+                    if (self.reloadAfterAnimation)
+                    {
+                        [self.collectionView reloadData];
+                        self.reloadAfterAnimation = NO;
+                    }
                     self.batchUpdates = nil;
                     
                 }];
-            
-                // delayed item updates
-                if (self.updatedIndexPaths.count > 0){
-                    
-                    [self.collectionView performBatchUpdates:^{
-                        
-                        [self.collectionView reloadItemsAtIndexPaths:self.updatedIndexPaths];
-                        
-                    } completion:^(BOOL finished) {
-                        
-                        self.updatedIndexPaths = nil;
-                        
-                    }];
-                }
 
             }
             
@@ -255,6 +253,5 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
 {
     return nil;
 }
-
 
 @end

--- a/RZCollectionList/Classes/RZCollectionListTableViewDataSource.h
+++ b/RZCollectionList/Classes/RZCollectionListTableViewDataSource.h
@@ -16,10 +16,10 @@
 
 @optional
 
-//! Implement this to immediately update a cell's contents as part of a batch update, as opposed to a parallel animation (which can look strange)
+//! Implement this to immediately update a cell's contents as part of a batch update, as opposed to reloading after the animations complete
 /*!
-    The indexPath parameter is the index path of the object in the collection list at the time this method is called, NOT the index path of the cell being updated.
-*/
+    The indexPath parameter is the index path of the object in the collection list at the time this method is called, NOT the index path of the cell being updated!
+ */
 - (void)tableView:(UITableView*)tableView updateCell:(UITableViewCell*)cell forObject:(id)object atIndexPath:(NSIndexPath*)indexPath;
 
 - (NSString*)tableView:(UITableView*)tableView titleForHeaderInSection:(NSInteger)section;


### PR DESCRIPTION
@joe-goullaud minor fix

There is an issue with the collection view data source when an item gets updated. The normal batch update block also gets called, resulting in competing animations that don't layer correctly, and cells get stuck.

We may need to consider just removing the delayed item reload if anything else happened during the update - they don't seem to play nicely if two blocks are called in succession this way. Alternatively we could dispatch the update block until the next run loop to see if it makes a difference. I have a feeling it will just abort the in-progress animation.
