### PR TITLE
Section Index Title Fixes

### DIFF
--- a/RZCollectionList/Classes/RZCompositeCollectionList.m
+++ b/RZCollectionList/Classes/RZCompositeCollectionList.m
@@ -387,15 +387,13 @@ typedef enum {
 
 - (NSArray*)sectionIndexTitles
 {
-    NSArray *sections = self.sections;
-    NSMutableArray *indexTitles = [NSMutableArray arrayWithCapacity:sections.count];
+    NSMutableArray *indexTitles = [NSMutableArray array];
     
-    [sections enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        NSString *indexTitle = ((id<RZCollectionListSectionInfo>)obj).indexTitle;
-        
-        if (indexTitle)
+    [self.sourceLists enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        NSArray *listTitles = [(id<RZCollectionList>)obj sectionIndexTitles];
+        if (listTitles.count > 0)
         {
-            [indexTitles addObject:indexTitle];
+            [indexTitles addObjectsFromArray:listTitles];
         }
     }];
     
@@ -464,7 +462,6 @@ typedef enum {
     {
         NSArray *filteredArray = [self.sections filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", sectionName]];
         id<RZCollectionListSectionInfo> section = [filteredArray lastObject];
-        
         sectionIndexTitle = section.indexTitle;
     }
     

--- a/RZCollectionList/Classes/RZFetchedCollectionList.m
+++ b/RZCollectionList/Classes/RZFetchedCollectionList.m
@@ -192,7 +192,7 @@
         return [self.delegate collectionList:self sectionIndexTitleForSectionName:sectionName];
     }
     
-    return nil;
+    return [self.controller sectionIndexTitleForSectionName:sectionName];
 }
 
 @end


### PR DESCRIPTION
@joe-goullaud Fairly high-priority for an ongoing project
1. The fetched list wasn't defaulting back to the fetched results controller's index title implementation, resulting in nil section index titles.
2. The composite list was building its section index titles array from each individual section's index title, rather than the collective list (which is de-duped)
