### PR TITLE
Disable editing rows by default in TableView data source 

### DIFF
--- a/RZCollectionList/Classes/RZCollectionListTableViewDataSource.m
+++ b/RZCollectionList/Classes/RZCollectionListTableViewDataSource.m
@@ -120,7 +120,7 @@
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    BOOL canEdit = YES;
+    BOOL canEdit = NO;
     
     if (self.delegate && [self.delegate respondsToSelector:@selector(tableView:canEditObject:atIndexPath:)])
     {


### PR DESCRIPTION
@joe-goullaud By popular request from all of our iOS devs. Swipe to delete should be the exception, not the rule.
