### PR TITLE
Fix bug with updates to collection view while not onscreen yet

### DIFF
--- a/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.m
+++ b/RZCollectionList/Classes/RZCollectionListCollectionViewDataSource.m
@@ -214,7 +214,8 @@ typedef void(^RZCollectionListCollectionViewBatchUpdateBlock)(void);
 {
     if (self.animateCollectionChanges)
     {
-        if (self.useBatchUpdating)
+        // If collection view isn't on screen yet, don't animate anything - it doesn't like that.
+        if (self.useBatchUpdating && self.collectionView.window != nil)
         {
             if (self.batchUpdates.count > 0)
             {


### PR DESCRIPTION
Trying to animate changes to the collection view if it doesn't have a window (isn't on screen) results in an exception.

This fixes a recurrent bug with initializing a data source in `viewDidLoad` before the collection view has a chance to lay itself out at least once.
