### PR TITLE
Bugfix/arrouse/removing from section

### DIFF
--- a/RZCollectionList/Classes/RZArrayCollectionList.m
+++ b/RZCollectionList/Classes/RZArrayCollectionList.m
@@ -341,7 +341,7 @@
     RZArrayCollectionListSectionInfo *sectionInfo = [self sectionInfoForSection:indexPath.section];
     
     if ( indexPath.row >= sectionInfo.numberOfObjects ) {
-        return;
+        @throw [NSException exceptionWithName:NSRangeException reason:[NSString stringWithFormat:@"Index is outside the bounds for the section. Index:%lu in section %lu is greater than the number of objects in the section:%lu", (unsigned long)indexPath.row, (unsigned long)indexPath.section, (unsigned long)sectionInfo.numberOfObjects] userInfo:nil];
     }
     
     NSUInteger index = sectionInfo.indexOffset + indexPath.row;


### PR DESCRIPTION
@Raizlabs/maintainers-ios 

If you have a multisection table and some middle sections don't have any objects.  If you try and remove an object in from an empty section (or an index outside the range of the section) it will just move to the next section and remove whatever object it gets.

In this case we just perform a NOP.
