### PR TITLE
Remove all objects ending batch update

### DIFF
--- a/RZCollectionList/Classes/RZArrayCollectionList.m
+++ b/RZCollectionList/Classes/RZArrayCollectionList.m
@@ -97,7 +97,6 @@
             self.sectionsInfo = [[NSArray array] mutableCopy];
         }
 
-        
         [self.sectionsInfo enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             ((RZArrayCollectionListSectionInfo*)obj).arrayList = self;
         }];

--- a/RZCollectionList/Classes/RZFilteredCollectionList.m
+++ b/RZCollectionList/Classes/RZFilteredCollectionList.m
@@ -497,7 +497,7 @@ typedef enum {
 
 - (void)addSourceObject:(id)object atSourceIndexPath:(NSIndexPath*)indexPath
 {
-    if (indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
     {
         NSMutableIndexSet *sectionIndexSet = [self.objectIndexesForSection objectAtIndex:indexPath.section];
         [sectionIndexSet shiftIndexesStartingAtIndex:indexPath.row by:1];
@@ -528,7 +528,7 @@ typedef enum {
 
 - (void)removeSourceObject:(id)object atSourceIndexPath:(NSIndexPath*)indexPath
 {
-    if (indexPath.section >= 0 && indexPath.section < self.cachedObjectIndexesForSectionDeep.count && indexPath.section < self.objectIndexesForSection.count)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < self.cachedObjectIndexesForSectionDeep.count && indexPath.section < self.objectIndexesForSection.count)
     {
         NSMutableIndexSet *cachedSectionIndexSet = [self.cachedObjectIndexesForSectionDeep objectAtIndex:indexPath.section];
         
@@ -551,7 +551,7 @@ typedef enum {
     // All we need to do here is remove the index from the set
     NSIndexPath *indexPath = moveNotification.indexPath;
     NSUInteger sectionCount = self.objectIndexesForSection.count;
-    if (indexPath.section >= 0 && indexPath.section < sectionCount)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < sectionCount)
     {
         NSMutableIndexSet *fromSectionObjectIndexSet = [self.objectIndexesForSection objectAtIndex:indexPath.section];
         
@@ -566,7 +566,7 @@ typedef enum {
     NSIndexPath *indexPath = moveNotification.indexPath;
     NSIndexPath *newIndexPath = moveNotification.nuIndexPath;
     NSUInteger sectionCount = self.objectIndexesForSection.count;
-    if (newIndexPath.section >= 0 && newIndexPath.section < sectionCount)
+    if (newIndexPath != nil && newIndexPath.section >= 0 && newIndexPath.section < sectionCount)
     {
         // Occasionally, a move produced by a fetched list will actually result in the object no longer passing the predicate.
         // Need to handle that case.
@@ -634,7 +634,7 @@ typedef enum {
 
 - (void)updateSourceObject:(id)object atSourceIndexPath:(NSIndexPath*)indexPath currentSourceIndexPath:(NSIndexPath *)currentIndexPath
 {
-    if (indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
     {
         BOOL isInFilteredList = [self sourceIndexPathIsInFilteredList:indexPath cached:YES];
         BOOL passesPredicate = ([self.predicate evaluateWithObject:object] || nil == self.predicate);
@@ -675,7 +675,7 @@ typedef enum {
 
 - (void)filterOutSourceObject:(id)object atSourceIndexPath:(NSIndexPath*)indexPath
 {
-    if (indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
     {
         NSMutableIndexSet *sectionIndexSet = [self.objectIndexesForSection objectAtIndex:indexPath.section];
         
@@ -696,7 +696,7 @@ typedef enum {
 
 - (void)unfilterSourceObject:(id)object atSourceIndexPath:(NSIndexPath*)indexPath
 {
-    if (indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
+    if (indexPath != nil && indexPath.section >= 0 && indexPath.section < self.objectIndexesForSection.count)
     {
         [self confirmPotentialUpdates];
         

--- a/RZCollectionList/Classes/RZObserverCollection.m
+++ b/RZCollectionList/Classes/RZObserverCollection.m
@@ -56,8 +56,11 @@
     else
     {
 #if RZOCL_POINTER_ARRAY_AVAILABLE
-        [self.observerPointerArray addPointer:(__bridge void *)(observer)];
+        if ( [self indexOfObserverInPointerArray:observer] == NSNotFound ) {
+            [self.observerPointerArray addPointer:(__bridge void *)(observer)];
+        }
 #else
+        
         NSString *addressString = [NSString stringWithFormat:@"%p", observer];
         if (![self.observerAddresses containsObject:addressString])
         {


### PR DESCRIPTION
@Raizlabs/maintainers-ios this is to fix a bug that if you are already in a batch update and you want to remove all objects as part of that update, it will end the batch update causing anything else that happens as part of the batch to not be within the begin/end updates.

Also changed the use to the `self.isBatchUpdating` getter that is specified.