### PR TITLE
RZSortedCollectionList indexPathForObject should return nil when object isn't found

### DIFF
--- a/RZCollectionList/Classes/RZSortedCollectionList.m
+++ b/RZCollectionList/Classes/RZSortedCollectionList.m
@@ -163,7 +163,7 @@ typedef enum {
 - (NSIndexPath*)indexPathForObject:(id)object
 {
     NSUInteger indexOfObject = [self.sortedListObjects indexOfObject:object];
-    return [NSIndexPath indexPathForRow:indexOfObject inSection:0];
+    return (indexOfObject != NSNotFound) ? [NSIndexPath indexPathForRow:indexOfObject inSection:0] : nil;
 }
 
 - (NSString *)sectionIndexTitleForSectionName:(NSString *)sectionName


### PR DESCRIPTION
[RZSortedCollectionList indexPathForObject] should return nil when the object isn't found. Currently it returns an NSIndexPath with a row of NSNotFound and a section of 0.