### PR TITLE
Bugfix in RZArrayCollectionList -objectAtIndexPath:

### DIFF
--- a/RZCollectionList/Classes/RZArrayCollectionList.m
+++ b/RZCollectionList/Classes/RZArrayCollectionList.m
@@ -882,13 +882,11 @@
 {
     RZArrayCollectionListSectionInfo *section = [self sectionInfoForSection:indexPath.section];
     
-    NSUInteger index = section.indexOffset + indexPath.row;
-    
     id object = nil;
     
-    if (index < [self.objects count])
+    if (indexPath.row < section.numberOfObjects)
     {
-        object = [self.objects objectAtIndex:index];
+        object = [section.objects objectAtIndex:indexPath.row];
     }
     
     return object;


### PR DESCRIPTION
Could access objects outside of a section by supplying an index path with row greater than the number of objects in the given section.