### PR TITLE
RZFilteredCollectionList - indexPathOfObject: bug

### DIFF
--- a/RZCollectionList-Demo/RZCollectionList-DemoTests/RZFilteredCollectionListTests.m
+++ b/RZCollectionList-Demo/RZCollectionList-DemoTests/RZFilteredCollectionListTests.m
@@ -744,6 +744,21 @@ typedef void (^RZCollectionListTestObserverDidChangeObjectBlock)(id<RZCollection
     [self logCollectionList:self.filteredList];
 }
 
+- (void)test12IndexPathOfObjectInFilteredList
+{
+    NSArray *array = @[@"Bob", @"Mary", @"John", @"June", @"Brad", @"Rudi", @"Richard", @"Ray", @"Bun"];
+    RZArrayCollectionList *arrayList = [[RZArrayCollectionList alloc] initWithArray:array sectionNameKeyPath:nil];
+    RZFilteredCollectionList *filteredList = [[RZFilteredCollectionList alloc] initWithSourceList:arrayList predicate:nil];
+
+    NSIndexPath *initialIndexPath = [NSIndexPath indexPathForRow:7 inSection:0];
+    id object = [filteredList objectAtIndexPath:initialIndexPath];
+
+    filteredList.predicate = [NSPredicate predicateWithFormat:@"self contains[c] %@", @"u"];
+
+    NSIndexPath *newIndexPath = [filteredList indexPathForObject:object];
+    XCTAssertNil(newIndexPath, @"IndexPath should be nil, instead it is: %@", newIndexPath);
+}
+
 #pragma mark - RZCollectionListObserver
 
 - (void)collectionListWillChangeContent:(id<RZCollectionList>)collectionList

--- a/RZCollectionList/Classes/RZFilteredCollectionList.m
+++ b/RZCollectionList/Classes/RZFilteredCollectionList.m
@@ -280,9 +280,14 @@ typedef enum {
     NSUInteger filteredSection = [self filteredSectionIndexForSourceSectionIndex:indexPath.section cached:cached];
     
     NSIndexSet *sectionIndexSet = cached ? [self.cachedObjectIndexesForSectionDeep objectAtIndex:indexPath.section] : [self.objectIndexesForSection objectAtIndex:indexPath.section];
-    NSUInteger filteredRow = [sectionIndexSet countOfIndexesInRange:NSMakeRange(0, indexPath.row)];
-    
-    return [NSIndexPath indexPathForRow:filteredRow inSection:filteredSection];
+
+    if ([sectionIndexSet containsIndex:indexPath.row]) {
+        NSUInteger filteredRow = [sectionIndexSet countOfIndexesInRange:NSMakeRange(0, indexPath.row)];
+        return [NSIndexPath indexPathForRow:filteredRow inSection:filteredSection];
+    }
+    else {
+        return nil;
+    }
 }
 
 - (NSUInteger)filteredSectionIndexForSourceSectionIndex:(NSUInteger)section


### PR DESCRIPTION
Fixed bug where calling indexPathOfObject: was returning an incorrect indexPath if the object is in the source list, but not the newly filtered list. I added a test as well.