### PR TITLE
Fixing some breaking changes with Xcode 7.3

### DIFF
--- a/RZCollectionList/Classes/RZCollectionListProtocol.h
+++ b/RZCollectionList/Classes/RZCollectionListProtocol.h
@@ -137,20 +137,20 @@
 @end
 
 /**
- *  An observer protocol to receive RZCollectionList change events
- */
-@protocol RZCollectionListObserver <NSObject>
-
-/**
  *  All of the types of changes for update notifications.
  */
-typedef enum {
+typedef NS_ENUM(NSInteger, RZCollectionListChangeType ) {
     RZCollectionListChangeInvalid = -1,
     RZCollectionListChangeInsert = 1,
     RZCollectionListChangeDelete = 2,
     RZCollectionListChangeMove = 3,
     RZCollectionListChangeUpdate = 4
-} RZCollectionListChangeType;
+};
+
+/**
+ *  An observer protocol to receive RZCollectionList change events
+ */
+@protocol RZCollectionListObserver <NSObject>
 
 @required
 


### PR DESCRIPTION
This fixes an issue in Xcode 7.3 where you can't define a protocol inside of a protocol.  It also allows you to specify the enum types within swift code.

@KingOfBrian @bsmithraiz Please take a look when you get a chance.  would love to merge this in as soon as possible